### PR TITLE
Fixes Unity warnings

### DIFF
--- a/LICENSE.meta
+++ b/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dcf626c12805336acb575da02262f447
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Tokenizers/Decoders/Decoders.cs
+++ b/Runtime/Tokenizers/Decoders/Decoders.cs
@@ -322,7 +322,6 @@ namespace HuggingFace.SharpTransformers.Decoders
     class DecoderSequence : Decoder_
     {
         public List<Decoder_> Decoders;
-        public JObject Config;
 
         public DecoderSequence(JObject config) : base(config)
         {
@@ -354,7 +353,7 @@ namespace HuggingFace.SharpTransformers.Decoders
         /// </summary>
         /// <param name="tokens"></param>
         /// <returns></returns>
-        public List<string> DecodeChain(List<string> tokens)
+        public new List<string> DecodeChain(List<string> tokens)
         {
             return this.Decoders.Aggregate(tokens, (currentTokens, decoder) => decoder.DecodeChain(currentTokens));
         }

--- a/Runtime/Tokenizers/Normalizers/Normalizers.cs
+++ b/Runtime/Tokenizers/Normalizers/Normalizers.cs
@@ -85,7 +85,6 @@ namespace HuggingFace.SharpTransformers.Normalizers
     {
         public BertNormalizer(JObject config) : base(config)
         {
-
         }
 
         /// <summary>
@@ -114,35 +113,34 @@ namespace HuggingFace.SharpTransformers.Normalizers
                 {
                     output.Append(character);
                 }
-
             }
             return output.ToString();
         }
 
         /// <summary>
         /// Checks whether the given Unicode codepoint represents a CJK (Chinese, Japanese, or Korean) character.
-        /// 
+        ///
         /// A "chinese character" is defined as anything in the CJK Unicode block:
         /// https://en.wikipedia.org/wiki/CJK_Unified_Ideographs_(Unicode_block)
-        /// 
+        ///
         /// Note that the CJK Unicode block is NOT all Japanese and Korean characters, despite its name.
         /// The modern Korean Hangul alphabet is a different block, as is Japanese Hiragana and Katakana.
         /// Those alphabets are used to write space-separated words, so they are not treated specially
         /// and are handled like all other languages.
-        /// 
+        ///
         /// </summary>
         /// <param name="unicodeCodePoint">The Unicode codepoint to check.</param>
         /// <returns name="bool"> True if the codepoint represents a CJK character, false otherwise. </returns>
         public bool IsChineseChar(int unicodeCodePoint)
         {
             return (unicodeCodePoint >= 0x4E00 && unicodeCodePoint <= 0x9FFF) ||
-           (unicodeCodePoint >= 0x3400 && unicodeCodePoint <= 0x4DBF) ||
-           (unicodeCodePoint >= 0x20000 && unicodeCodePoint <= 0x2A6DF) ||
-           (unicodeCodePoint >= 0x2A700 && unicodeCodePoint <= 0x2B73F) ||
-           (unicodeCodePoint >= 0x2B740 && unicodeCodePoint <= 0x2B81F) ||
-           (unicodeCodePoint >= 0x2B820 && unicodeCodePoint <= 0x2CEAF) ||
-           (unicodeCodePoint >= 0xF900 && unicodeCodePoint <= 0xFAFF) ||
-           (unicodeCodePoint >= 0x2F800 && unicodeCodePoint <= 0x2FA1F);
+                (unicodeCodePoint >= 0x3400 && unicodeCodePoint <= 0x4DBF) ||
+                (unicodeCodePoint >= 0x20000 && unicodeCodePoint <= 0x2A6DF) ||
+                (unicodeCodePoint >= 0x2A700 && unicodeCodePoint <= 0x2B73F) ||
+                (unicodeCodePoint >= 0x2B740 && unicodeCodePoint <= 0x2B81F) ||
+                (unicodeCodePoint >= 0x2B820 && unicodeCodePoint <= 0x2CEAF) ||
+                (unicodeCodePoint >= 0xF900 && unicodeCodePoint <= 0xFAFF) ||
+                (unicodeCodePoint >= 0x2F800 && unicodeCodePoint <= 0x2FA1F);
         }
 
         /// <summary>
@@ -198,11 +196,9 @@ namespace HuggingFace.SharpTransformers.Normalizers
     }
 
 
-
     public class NormalizerSequence : Normalizer
     {
         public List<Normalizer> Normalizers;
-        public JObject Config;
 
         /// <summary>
         /// Create a new instance of NormalizerSequence
@@ -210,7 +206,7 @@ namespace HuggingFace.SharpTransformers.Normalizers
         /// <param name="config">The configuration object</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public NormalizerSequence(JObject config): base(config)
+        public NormalizerSequence(JObject config) : base(config)
         {
             string jsonString = config.ToString();
 
@@ -224,7 +220,7 @@ namespace HuggingFace.SharpTransformers.Normalizers
             }
 
             Normalizers = new List<Normalizer>();
-        
+
             foreach (JObject normalizerConfig in config["normalizers"])
             {
                 var normalizer = Normalizer.FromConfig(normalizerConfig);
@@ -238,14 +234,13 @@ namespace HuggingFace.SharpTransformers.Normalizers
             }
         }
 
-
         /// <summary>
         /// Apply a sequence of Normalizes to the input text.
         /// </summary>
         /// <param name="text">The text to normalize</param>
         /// <returns>The normalized text</returns>
         /// <exception cref="ArgumentNullException"></exception>
-        public string Normalize(string text)
+        public new string Normalize(string text)
         {
             if (text == null)
             {
@@ -268,7 +263,6 @@ namespace HuggingFace.SharpTransformers.Normalizers
     {
         public Prepend(JObject config) : base(config)
         {
-
         }
 
         /// <summary>
@@ -292,7 +286,6 @@ namespace HuggingFace.SharpTransformers.Normalizers
     {
         public Replace(JObject config) : base(config)
         {
-
         }
 
         /// <summary>

--- a/Runtime/Tokenizers/Normalizers/NormalizersUtils.cs
+++ b/Runtime/Tokenizers/Normalizers/NormalizersUtils.cs
@@ -27,7 +27,6 @@ namespace HuggingFace.SharpTransformers.NormalizersUtils
             else
             {
                 throw new Exception($"Unknown pattern type: {pattern}");
-                return null;
             }
         }
     }

--- a/Runtime/Tokenizers/PostProcessors/PostProcessors.cs
+++ b/Runtime/Tokenizers/PostProcessors/PostProcessors.cs
@@ -74,8 +74,6 @@ namespace HuggingFace.SharpTransformers.PostProcessors
     /// </summary>
     public class TemplateProcessing : PostProcessor
     {
-        public JObject Config;
-        
         // The template for a single sequence of tokens.
         public JArray Single;
         

--- a/Runtime/Tokenizers/Tokenizers/Tokenizers.cs
+++ b/Runtime/Tokenizers/Tokenizers/Tokenizers.cs
@@ -179,14 +179,8 @@ namespace HuggingFace.SharpTransformers.Tokenizers
         }
     }
 
-
     public class WordPieceTokenizer : TokenizerModel
     {
-        public JObject Config;
-        public List<string> Vocab;
-        public Dictionary<string, int> TokensToIds;
-        public int? UnkTokenId; // Thanks to int?, the variable can hold an integer value or be null
-        public string UnkToken;
         public string ContinuingSubwordPrefix;
 
         public WordPieceTokenizer(JObject config) : base(config)
@@ -215,7 +209,7 @@ namespace HuggingFace.SharpTransformers.Tokenizers
         /// </summary>
         /// <param name="tokens">The tokens to encode.</param>
         /// <returns>An array of encoded tokens.</returns>
-        public List<string> Encode(List<string> tokens)
+        public new List<string> Encode(List<string> tokens)
         {
             // Initialize a List<string> to store the encoded tokens
             var OutputTokens = new List<string>();
@@ -293,7 +287,7 @@ namespace HuggingFace.SharpTransformers.Tokenizers
         /// </summary>
         /// <param name="ids">The token IDs to convert.</param>
         /// <returns>The converted tokens.</returns>
-        public List<string> ConvertIdsToTokens(List<int> ids)
+        public new List<string> ConvertIdsToTokens(List<int> ids)
         {
             /*
              Select is used instead of map to transform the list of IDs into a list of tokens.
@@ -304,7 +298,7 @@ namespace HuggingFace.SharpTransformers.Tokenizers
             return tokens;
         }
 
-        public List<int> ConvertTokensToIds(List<string> tokens)
+        public new List<int> ConvertTokensToIds(List<string> tokens)
         {
             // Create an array of token IDs by mapping each token to its corresponding ID
             List<int> ids = new List<int>();
@@ -323,7 +317,7 @@ namespace HuggingFace.SharpTransformers.Tokenizers
             return ids;
         }
 
-        public List<int> Fuse(List<int> arr, int value)
+        public new List<int> Fuse(List<int> arr, int value)
         {
             List<int> fused = new List<int>();
             int i = 0;


### PR DESCRIPTION
Fixes the following Unity warnings:
- missing README.md.meta
- overridden variables / functions show "hides inherited" warnings